### PR TITLE
Commandline wrapper and some usability fixes.

### DIFF
--- a/Align_cameras.py
+++ b/Align_cameras.py
@@ -29,12 +29,7 @@ def align_cameras(raw_image, nucl_segm_image, crop_dir, crop_box_index, offset =
     crop_x_max = min(vpairs[1]+offset, max_margin)
     print('Cropboxes found...')
 
-    seg_dir = os.path.dirname(nucl_segm_image)
-    cur_name = os.path.basename(nucl_segm_image)
-    file_prefix = os.path.splitext(cur_name)[0]
-    file_ext = os.path.splitext(cur_name)[1]
-    nuc_label = read_segments(seg_dir, file_prefix, file_ext, 'nuclei')
-
+    nuc_label = read_image(nucl_segm_image)
     nuc_label = nuc_label[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
 
     if type(nuc_label) is np.ndarray:

--- a/Align_cameras.py
+++ b/Align_cameras.py
@@ -1,21 +1,15 @@
 import numpy as np
 import pandas as pd
-import seaborn as sns
-import glob
-from skimage import io
-import matplotlib.pyplot as plt
-from skimage import measure
-from skimage.transform import rescale
-import h5py
-from pyklb import readfull
 from Label_read import *
+from io_utils import read_image
 
 # This method aligns Short camera to Long one, to be used for TF quantification obtained with Cam_Short.
 # The code works under the assumption that TF should be localized in the nucleus.
 
 # Parameters:
-# # raw_dir = path prefix for raw data (including channel)
-# # nucl_segm_dir = directory with nuclear segmentation results
+# # raw_file = path raw data file(including channel)
+# # nucl_segm_dir = directory with nuclear segmentation of corresponding time points
+# # crop_dir = the directory with the crop data
 # # time = which time to use for alignment; theoretically, all the timepoints should produce similar results.
 # # offset = offset that was used for cropping;
 # # max_margin = 2048, original size of images;
@@ -23,34 +17,35 @@ from Label_read import *
 #Returns
 # # x_shift and y_shift that maximize the signal within the segments found through nuclear segmentation.
 
-def align_cameras(raw_dir, nucl_segm_dir, time = 50, offset = 150, max_margin = 2048):
-    vpairs = pd.read_csv(nucl_segm_dir+'/vpairs.csv', index_col = [0])
-    hpairs = pd.read_csv(nucl_segm_dir+'/hpairs.csv', index_col = [0]) 
-    vpairs = tuple(map(int, vpairs['all'][0][1:-1].split(', ')))
-    hpairs = tuple(map(int, hpairs['all'][0][1:-1].split(', ')))
+
+def align_cameras(raw_image, nucl_segm_image, crop_dir, crop_box_index, offset = 150, max_margin = 2048):
+    vpairs = pd.read_csv(os.path.join(crop_dir,'vpairs.csv'), index_col = [0])
+    hpairs = pd.read_csv(os.path.join(crop_dir,'hpairs.csv'), index_col = [0])
+    vpairs = tuple(map(int, vpairs['all'][crop_box_index][1:-1].split(', ')))
+    hpairs = tuple(map(int, hpairs['all'][crop_box_index][1:-1].split(', ')))
     crop_y_min = max(hpairs[0]-offset,0)
     crop_y_max = min(hpairs[1]+offset, max_margin)
     crop_x_min = max(vpairs[0]-offset,0)
     crop_x_max = min(vpairs[1]+offset, max_margin)
     print('Cropboxes found...')
     
-    _, nuc_labels = read_segments('', nucl_segm_dir)
-    print('Nuclear Segmentations found...')
-    str_time = str(time).zfill(5)
-    
-    tf = readfull(raw_dir+'/out/folder_Cam_Short_'+str_time+'.lux/klbOut_Cam_Short_'+str_time+'.lux.klb')
+    _, nuc_label = read_segments('', nucl_segm_image,'')
+    nuc_label = nuc_label[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
 
-    mean_signal = {}
-    for x_shift in range(-50, 50):
-        mean_signal[x_shift] = {}
-        for y_shift in range(-50,50):
-            tf_signal = tf[:, 
-                     (crop_x_min+x_shift):(crop_x_max+x_shift), 
-                     (crop_y_min+y_shift):(crop_y_max+y_shift)]
-            mean_signal[x_shift][y_shift] = tf_signal[nuc_labels[time].astype(bool)].mean()
-    ind = pd.DataFrame(mean_signal).stack().argmax()
-    shs = pd.DataFrame(mean_signal).stack().index[ind]
-    x_shift = shs[1]
-    y_shift = shs[0]
-    print('Alignments found.')
-    return x_shift, y_shift
+    if type(nuc_label) is np.ndarray:
+        print('Nuclear Segmentations found...')
+        tf = read_image(raw_image)
+        mean_signal = {}
+        for x_shift in range(-50, 50):
+            mean_signal[x_shift] = {}
+            for y_shift in range(-50,50):
+                tf_signal = tf[:,(crop_x_min+x_shift):(crop_x_max+x_shift),
+                         (crop_y_min+y_shift):(crop_y_max+y_shift)]
+                mean_signal[x_shift][y_shift] = tf_signal[nuc_label.astype(bool)].mean()
+        ind = pd.DataFrame(mean_signal).stack().argmax()
+        shs = pd.DataFrame(mean_signal).stack().index[ind]
+        x_shift = shs[1]
+        y_shift = shs[0]
+        return x_shift, y_shift
+    else:
+        return None, None

--- a/Align_cameras.py
+++ b/Align_cameras.py
@@ -28,8 +28,13 @@ def align_cameras(raw_image, nucl_segm_image, crop_dir, crop_box_index, offset =
     crop_x_min = max(vpairs[0]-offset,0)
     crop_x_max = min(vpairs[1]+offset, max_margin)
     print('Cropboxes found...')
-    
-    _, nuc_label = read_segments('', nucl_segm_image,'')
+
+    seg_dir = os.path.dirname(nucl_segm_image)
+    cur_name = os.path.basename(nucl_segm_image)
+    file_prefix = os.path.splitext(cur_name)[0]
+    file_ext = os.path.splitext(cur_name)[1]
+    nuc_label = read_segments(seg_dir, file_prefix, file_ext, 'nuclei')
+
     nuc_label = nuc_label[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
 
     if type(nuc_label) is np.ndarray:

--- a/Label_read.py
+++ b/Label_read.py
@@ -12,25 +12,42 @@ import os
 # # nuc_mask = nuclear labels indexed
 # Will return None if one or both the segmentation types is unavailable
 
-def read_segments(mem_segm_file, nucl_segm_file, nucl_segm_file_corrected):
+def read_segments(data_dir, file_prefix, file_ext, segmentation_type):
     # Initialize masks to None
-    nucl_mask = None
-    memb_mask = None
-
+    label_mask = None
     # nuclei
     try:
-        if os.path.exists(nucl_segm_file_corrected): # Look for corrected mask first
-            nucl_mask = read_image(nucl_segm_file_corrected)
-        elif os.path.exists(nucl_segm_file):
-            nucl_mask = read_image(nucl_segm_file)
+        if segmentation_type == "membrane":
+            mem_file = os.path.join(data_dir, file_prefix + "_cp_masks" + file_ext)
+            if os.path.exists(mem_file):
+                label_mask = read_image(mem_file)
+            else: # Check the other cam
+                if 'Long' in file_prefix:
+                    replace_cam_prefix = file_prefix.replace('Long','Short')
+                else:
+                    replace_cam_prefix = file_prefix.replace('Short','Long')
+                mem_file = os.path.join(data_dir, replace_cam_prefix + "_cp_masks" + file_ext)
+                if os.path.exists(mem_file):
+                    label_mask = read_image(mem_file)
+        else:
+            nucl_segm_file = os.path.join(data_dir,file_prefix + ".label" + file_ext)
+            nucl_segm_file_corrected = os.path.join(data_dir,file_prefix + "_SegmentationCorrected" + file_ext)
+            if os.path.exists(nucl_segm_file_corrected): # Look for corrected mask first
+                label_mask = read_image(nucl_segm_file_corrected)
+            elif os.path.exists(nucl_segm_file):
+                label_mask = read_image(nucl_segm_file)
+            else: # Check the other Cam
+                if 'Long' in file_prefix:
+                    replace_cam_prefix = file_prefix.replace('Long','Short')
+                else:
+                    replace_cam_prefix = file_prefix.replace('Short','Long')
+                nucl_segm_file = os.path.join(data_dir,replace_cam_prefix + ".label" + file_ext)
+                nucl_segm_file_corrected = os.path.join(data_dir,replace_cam_prefix + "_SegmentationCorrected" + file_ext)
+                if os.path.exists(nucl_segm_file_corrected): # Look for corrected mask first
+                    label_mask = read_image(nucl_segm_file_corrected)
+                elif os.path.exists(nucl_segm_file):
+                    label_mask = read_image(nucl_segm_file)
     except Exception as e:
-            print('Problem with reading nuclear segments', e)
+            print('Problem with reading segments', e)
 
-    #membrane 
-    try:
-        if os.path.exists(mem_segm_file):
-            memb_mask = read_image(mem_segm_file)
-    except Exception as e:
-        print('Problem with reading membrane segments', e)
-
-    return memb_mask, nucl_mask
+    return label_mask

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Mouse_embryo_analysis
+
+## Extracting transcription factor signal
+
+Load the `segmentation` conda environment and run the help:
+
+```commandline
+conda activate segmentation 
+python tf_extract.py tf-align-simple --help
+```
+
+Now, if you're wondering what the segmentation environment is, then please follow the instructions here to install it: [Install segmentation python environment](https://github.com/abiswas-odu/roi_convertor#install-on-your-own-machine)
+
+Executing the program requires using the commandline and parameters:
+
+```commandline
+python tf_extract.py tf-align-simple --orig_image_dir <dir> --nucl_seg_dir <label_dir> --crop_dir <crop_dir> --cropbox_index 7 --timestamp_min 0 --timestamp_max 10 --offset 150 --cell_volume_cutoff 2000
+```
+
+See --help for all the other parameters.

--- a/TF_quant_simple.py
+++ b/TF_quant_simple.py
@@ -73,13 +73,9 @@ def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, crop_dir,
             file_base = os.path.basename(cur_name).split(os.extsep)
             time_index = int(file_base[0].split('_')[-1])
 
-            # Get the label file names
-            mem_segm_file = os.path.join(mem_segm_dir, file_prefix + "_cp_masks" + file_ext)
-            nucl_segm_file = os.path.join(nucl_segm_dir,file_prefix + ".label" + file_ext)
-            nucl_segm_file_corrected = os.path.join(nucl_segm_dir,file_prefix + "_SegmentationCorrected" + file_ext)
-
+            # Get the nuclei label file names with same camera
             # read segmentation results
-            mem_label, nuc_label = read_segments(mem_segm_file, nucl_segm_file, nucl_segm_file_corrected)
+            nuc_label = read_segments(nucl_segm_dir, file_prefix, file_ext,"nuclei")
 
             #Extract nucl channel data
             if type(nuc_label) is np.ndarray:
@@ -92,6 +88,7 @@ def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, crop_dir,
                         nuc_vols[time_index][lab] = np.count_nonzero(nuc_label == lab)
 
             #Extract membrane channel data
+            mem_label = read_segments(mem_segm_dir, file_prefix, file_ext,"membrane")
             if type(mem_label) is np.ndarray:
                 a_mem = rescale(a, (1/(2*0.208),1/4,1/4), preserve_range = True, anti_aliasing = True)
                 sh = mem_label.shape

--- a/TF_quant_simple.py
+++ b/TF_quant_simple.py
@@ -1,14 +1,9 @@
 import numpy as np
 import pandas as pd
-import seaborn as sns
 import glob
-from skimage import io
-import matplotlib.pyplot as plt
-from skimage import measure
 from skimage.transform import rescale
-import h5py
-from pyklb import readfull
 from Label_read import *
+import os
 
 # Quantifies TF intensity in cells and nuclei for provided raw images and corresponding membrane and nuclear segmentation
 
@@ -29,66 +24,83 @@ from Label_read import *
 
 # Will return an empty dictionary if one of the segmentation types is unavailable
 
-def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, cell_volume_cutoff = 0, max_time = 120, offset = 150, max_margin = 2048, which_cam = 'Short', x_shift = 0, y_shift = 0):
-    
-    # read segmentation results
-    mem_labels, nuc_labels = read_segments(mem_segm_dir, nucl_segm_dir)
+
+def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, crop_dir,
+                crop_box_index=0, cell_volume_cutoff=0, min_time=0,
+                max_time=-1, offset=150,
+                max_margin=2048, x_shift=0, y_shift=0):
     
     # read cropboxes
-    vpairs = pd.read_csv(nucl_segm_dir+'/vpairs.csv', index_col = [0])
-    hpairs = pd.read_csv(nucl_segm_dir+'/hpairs.csv', index_col = [0]) 
-    vpairs = tuple(map(int, vpairs['all'][0][1:-1].split(', ')))
-    hpairs = tuple(map(int, hpairs['all'][0][1:-1].split(', ')))
+    vpairs = pd.read_csv(os.path.join(crop_dir,'vpairs.csv'), index_col=[0])
+    hpairs = pd.read_csv(os.path.join(crop_dir,'hpairs.csv'), index_col=[0])
+    vpairs = tuple(map(int, vpairs['all'][crop_box_index][1:-1].split(', ')))
+    hpairs = tuple(map(int, hpairs['all'][crop_box_index][1:-1].split(', ')))
     crop_y_min = max(hpairs[0]+y_shift-offset,0)
     crop_y_max = min(hpairs[1]+y_shift+offset, max_margin)
     crop_x_min = max(vpairs[0]+x_shift-offset,0)
     crop_x_max = min(vpairs[1]+x_shift+offset, max_margin)
     print('Cropboxes found...')
 
-    # read TF filenames
-    tf = glob.glob(raw_dir+'/out/folder_Cam_'+which_cam+'*/klbOut_Cam_'+which_cam+'*.klb')#klbOut_Cam_'+which_cam+'_*.klb')
-    #+'/out/folder_Cam_Long*/klbOut_Cam_Long*.klb')
+    # read TF filenames recursively
+    images = [os.path.join(dp, f)
+              for dp, dn, filenames in os.walk(raw_dir)
+              for f in filenames if (os.path.splitext(f)[1] == '.klb' or
+                                     os.path.splitext(f)[1] == '.h5' or
+                                     os.path.splitext(f)[1] == '.tif' or
+                                     os.path.splitext(f)[1] == '.npy')]
 
     nuc_tf_vals = {}
     mem_tf_vals = {}
+
+    # Set max_time to the len-1 to that we can loop till last
+    if max_time == -1:
+        max_time = len(images) - 1
     
     # loop through timepoints
-    for i, im in enumerate(np.sort(tf)):
+    images = np.sort(images)
+    for i, im in enumerate(images[min_time:max_time+1]):
         try:
-            print(im)
-            a = readfull(str(im))
-            a = a[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]           
-            cur_name = im.split('/')[-1]
-            #time = int(cur_name.split('.')[0].split('_')[-1])
-            time = int(cur_name.split('.')[0].split('_')[-1])
-            #print(time)
-            if int(time)< max_time:
-                cur_num = time
-                print(time)  
-                nuc_mask = nuc_labels[time]
-                sh = nuc_mask.shape
-                mem_mask = mem_labels[time]
-                #a_mem = zoom(a, (1/(2*0.208),1/4,1/4))
-                a_mem = rescale(a, 
-                                (1/(2*0.208),1/4,1/4), 
-                                preserve_range = True, 
-                                anti_aliasing = True)
-                sh = mem_mask.shape
-                #a_mem = np.swapaxes(a_mem, 1,2)
+            image_file_str = str(im)
+            print('Processing: '+ image_file_str)
+            a = read_image(image_file_str)
+            a = a[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
+            dir_name = os.path.dirname(image_file_str)
+
+            cur_name = os.path.basename(image_file_str)
+            file_prefix = os.path.splitext(cur_name)[0]
+            file_ext = os.path.splitext(cur_name)[1]
+            file_base = os.path.basename(cur_name).split(os.extsep)
+            time_index = int(file_base[0].split('_')[-1])
+
+            # Get the label file names
+            mem_segm_file = os.path.join(mem_segm_dir, file_prefix + "_cp_masks" + file_ext)
+            nucl_segm_file = os.path.join(nucl_segm_dir,file_prefix + ".label" + file_ext)
+            nucl_segm_file_corrected = os.path.join(nucl_segm_dir,file_prefix + "_SegmentationCorrected" + file_ext)
+
+            # read segmentation results
+            mem_label, nuc_label = read_segments(mem_segm_file, nucl_segm_file, nucl_segm_file_corrected)
+
+            #Extract nucl channel data
+            if type(nuc_label) is np.ndarray:
+                nuc_tf_vals[time_index] = {}
+                nuc_label = nuc_label[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
+                for lab in np.unique(nuc_label):
+                    nuc_tf_vals[time_index][lab] = np.mean(a[nuc_label == lab])
+
+            #Extract membrane channel data
+            if type(mem_label) is np.ndarray:
+                a_mem = rescale(a, (1/(2*0.208),1/4,1/4), preserve_range = True, anti_aliasing = True)
+                sh = mem_label.shape
                 a_mem = a_mem[:sh[0], :sh[1], :sh[2]]
                 sh = a_mem.shape
-                mem_mask = mem_mask[:sh[0], :sh[1], :sh[2]]
-                nuc_tf_vals[cur_num] = {}
-                mem_tf_vals[cur_num] = {}
-                for lab in np.unique(nuc_mask):
-                    nuc_tf_vals[cur_num][lab] = np.mean(a[nuc_mask == lab])
-                for lab in np.unique(mem_mask):
-                    if np.sum(mem_mask == lab)>=cell_volume_cutoff:
-                        mem_tf_vals[cur_num][lab] = np.mean(a_mem[mem_mask == lab])
-        except:
-            print('Skipping image')
-            print(im)
-            continue
-
+                mem_label = mem_label[:sh[0], :sh[1], :sh[2]]
+                mem_tf_vals[time_index] = {}
+                for lab in np.unique(mem_label):
+                    if np.sum(mem_label == lab) >= cell_volume_cutoff:
+                        mem_tf_vals[time_index][lab] = np.mean(a_mem[mem_label == lab])
+        except Exception as e:
+            print('Skipping image: ' + str(im))
+            print('Exception:')
+            print(e)
     return mem_tf_vals, nuc_tf_vals
 

--- a/TF_quant_simple.py
+++ b/TF_quant_simple.py
@@ -34,10 +34,10 @@ def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, crop_dir,
     hpairs = pd.read_csv(os.path.join(crop_dir,'hpairs.csv'), index_col=[0])
     vpairs = tuple(map(int, vpairs['all'][crop_box_index][1:-1].split(', ')))
     hpairs = tuple(map(int, hpairs['all'][crop_box_index][1:-1].split(', ')))
-    crop_y_min = max(hpairs[0]+y_shift-offset,0)
-    crop_y_max = min(hpairs[1]+y_shift+offset, max_margin)
-    crop_x_min = max(vpairs[0]+x_shift-offset,0)
-    crop_x_max = min(vpairs[1]+x_shift+offset, max_margin)
+    crop_y_min = max(hpairs[0]-offset,0)
+    crop_y_max = min(hpairs[1]+offset, max_margin)
+    crop_x_min = max(vpairs[0]-offset,0)
+    crop_x_max = min(vpairs[1]+offset, max_margin)
     print('Cropboxes found...')
 
     # read TF filenames recursively
@@ -64,7 +64,7 @@ def quantify_tf(raw_dir, mem_segm_dir, nucl_segm_dir, crop_dir,
             image_file_str = str(im)
             print('Processing: '+ image_file_str)
             a = read_image(image_file_str)
-            a = a[:, crop_x_min:crop_x_max, crop_y_min:crop_y_max]
+            a = a[:, (crop_x_min+x_shift):(crop_x_max+x_shift), (crop_y_min+y_shift):(crop_y_max+y_shift)]
             dir_name = os.path.dirname(image_file_str)
 
             cur_name = os.path.basename(image_file_str)

--- a/io_utils.py
+++ b/io_utils.py
@@ -1,0 +1,93 @@
+import os
+import numpy as np
+import h5py
+try:
+    import pyklb
+except ImportError:
+    print("pyklb install missing! All klb format operations will fail. ")
+import tifffile as tif
+from csbdeep.io import save_tiff_imagej_compatible
+
+def read_image(image_path_file):
+    """Read an image file in in klb/h5/tif/npy format.
+    Args:
+        image_path_file: Path to the image file in klb/h5/tif/npy format with the same extensions respectively.
+    Returns:
+        N-dimensional numpy array with the image pixels in 8/16/32-bit format
+    Raises:
+        ValueError: if the path is not found.
+        ValueError: if the image is not in one of the required formats.
+    """
+    if not os.path.exists(image_path_file):
+        raise ValueError(f"Image file not found '{image_path_file}'")
+    elif not os.path.isfile(image_path_file):
+        raise ValueError(f"Image not a file '{image_path_file}'")
+    elif not (os.path.splitext(image_path_file)[1] == '.klb' or
+              os.path.splitext(image_path_file)[1] == '.h5' or
+              os.path.splitext(image_path_file)[1] == '.tif' or
+              os.path.splitext(image_path_file)[1] == '.npy'):
+        raise ValueError(f"Image file not in supported format with appropriate extension '{image_path_file}'")
+
+    if image_path_file[-3:] == 'npy':
+        Xi = np.load(image_path_file)
+    elif image_path_file[-3:] == 'tif':
+        Xi = tif.imread(image_path_file)
+    elif (image_path_file[-2:] == 'h5'):
+        him = h5py.File(image_path_file, 'r')
+        Xi = him.get('Data')[:]
+    elif (image_path_file[-3:] == 'klb'):
+        Xi = pyklb.readfull(image_path_file)
+
+    print('loaded image shape:', Xi.shape)
+    return Xi
+
+def crop_image(Xi, row_1, row_2, col_1, col_2):
+    """Crop the X/Y dimension of the N-dimensional numpy array representing the image.
+    Args:
+        Xi: N-dimensional numpy array with the image pixels.
+        row_1: starting row
+        row_2: ending row
+        col_1: starting column
+        col_2: ending column
+    Returns:
+        N-dimensional numpy array with the cropped image pixels
+    """
+    return Xi[:, row_1:row_2, col_1:col_2]
+
+def crop_frames(Xi, frame_1, frame_2):
+    """Crop the X/Y dimension of the N-dimensional numpy array representing the image.
+    Args:
+        Xi: N-dimensional numpy array with the image pixels.
+        frame_1: starting frame
+        frame_2: ending frame
+    Returns:
+        N-dimensional numpy array with the cropped frames removed
+    """
+    return Xi[frame_1:frame_2, :, :]
+
+def write_image(labels, out_image_file, output_format):
+    """Writes a N-dimensional numpy array in tif format
+    Args:
+        labels:  N-dimensional numpy array
+        out_image_file: Path to the output image file including name.
+        output_format: The segmentation output format klb/h5/tif/npy.
+    Raises:
+        ValueError: if the path is invalid.
+    """
+
+    segmentation_file_name = ""
+    if output_format.upper() == "KLB":
+        segmentation_file_name = out_image_file + ".klb"
+        pyklb.writefull(labels, segmentation_file_name)
+    elif output_format.upper() == "H5":
+        segmentation_file_name = out_image_file + ".h5"
+        hf = h5py.File(segmentation_file_name, 'w')
+        hf.create_dataset('Data', data=labels)
+        hf.close()
+    elif output_format.upper() == "NPY":
+        segmentation_file_name = out_image_file + ".npy"
+        np.save(segmentation_file_name,labels)
+    else:
+        segmentation_file_name = out_image_file + ".tif"
+        save_tiff_imagej_compatible(segmentation_file_name, labels.astype('uint16'), axes='ZYX')
+    return segmentation_file_name

--- a/tf_extract.py
+++ b/tf_extract.py
@@ -3,7 +3,7 @@ from TF_quant_simple import *
 from time import time
 from Align_cameras import *
 
-__version__ = "1.1"
+__version__ = "1.2"
 
 @click.group()
 def cli():

--- a/tf_extract.py
+++ b/tf_extract.py
@@ -1,8 +1,9 @@
 import click
 from TF_quant_simple import *
 from time import time
+from Align_cameras import *
 
-__version__ = "1.0"
+__version__ = "1.1"
 
 @click.group()
 def cli():
@@ -42,24 +43,55 @@ def tf_align_simple(orig_image_dir, nucl_seg_dir, membrane_seg_dir,  crop_dir, c
                 timestamp_min, timestamp_max, offset, cell_volume_cutoff, max_margin, x_shift, y_shift):
     click.echo('Extracting transcription factor intensity...')
     t0 = time()
-    mem_tf_vals, nuc_tf_vals = quantify_tf(orig_image_dir, membrane_seg_dir, nucl_seg_dir, crop_dir,
+    mem_tf_vals, nuc_tf_vals, mem_vols, nuc_vols = quantify_tf(orig_image_dir, membrane_seg_dir, nucl_seg_dir, crop_dir,
                                            cropbox_index, cell_volume_cutoff, timestamp_min,
                                            timestamp_max, offset, max_margin, x_shift, y_shift)
 
     with open(os.path.join(crop_dir,'membrane_tf.csv'), 'w') as f_out:
-        f_out.write("Timestamp, Label ID, Label Intensity\n")
+        f_out.write("Timestamp, Label ID, Mean Label Intensity, Label Volume\n")
         for time_index, labels in mem_tf_vals.items():
             for label_id, intensity in labels.items():
-                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity) + '\n')
+                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity)
+                            + ',' + str(mem_vols[time_index][label_id]) + '\n')
 
     with open(os.path.join(crop_dir,'nuclei_tf.csv'), 'w') as f_out:
-        f_out.write("Timestamp, Label ID, Label Intensity\n")
+        f_out.write("Timestamp, Label ID, Mean Label Intensity, Label Volume\n")
         for time_index, labels in nuc_tf_vals.items():
             for label_id, intensity in labels.items():
-                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity) + '\n')
+                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity)
+                            + ',' + str(nuc_vols[time_index][label_id]) + '\n')
 
     t1 = time() - t0
     click.echo('Transcription factor intensity files generated here:' + crop_dir)
+    click.echo("Time elapsed: " + str(t1))
+
+
+@cli.command()
+@click.option('--orig_image_file',required=True,
+              type=click.Path(exists=True,file_okay=True,dir_okay=False,readable=True),
+              help="Original klb/tif/h5/npy file.")
+@click.option('--nucl_seg_file',required=False, default='',
+              type=click.Path(exists=True,file_okay=True,dir_okay=False,readable=True),
+              help="Directory with nuclei segmentation in same format as original images, klb/tif/h5/npy file.")
+@click.option('--crop_dir',required=True,
+              type=click.Path(exists=True,file_okay=False,dir_okay=True,readable=True),
+              help="The directory with hpair.csv and vpair.csv generated with generate-cropboxes. "
+                   "This is also the OUTPUT directory.")
+@click.option("--cropbox_index","-cbi", required=False, default=0, type=click.INT,
+              help="The cropbox to visualize for cropping.")
+@click.option("--offset","-of", required=False, default=150, type=click.INT,
+              help="The offset used during cropping.")
+@click.option("--max_margin", required=False, default=2048, type=click.INT,
+              help="Original size of images.")
+def align_cam(orig_image_file, nucl_seg_file, crop_dir, cropbox_index, offset, max_margin):
+    click.echo('Attempting to align cameras...')
+    t0 = time()
+    x_shift, y_shift = align_cameras(orig_image_file, nucl_seg_file, crop_dir,
+                                           cropbox_index, offset, max_margin)
+    print('X-shift:' + str(x_shift))
+    print('Y-shift:' + str(y_shift))
+
+    t1 = time() - t0
     click.echo("Time elapsed: " + str(t1))
 
 if __name__ == '__main__':

--- a/tf_extract.py
+++ b/tf_extract.py
@@ -1,0 +1,66 @@
+import click
+from TF_quant_simple import *
+from time import time
+
+__version__ = "1.0"
+
+@click.group()
+def cli():
+    pass
+
+@cli.command()
+@click.option('--orig_image_dir',required=True,
+              type=click.Path(exists=True,file_okay=False,dir_okay=True,readable=True),
+              help="Original klb/tif/h5/npy files.")
+@click.option('--nucl_seg_dir',required=False, default='',
+              type=click.Path(file_okay=False,dir_okay=True,readable=True),
+              help="Directory with nuclei segmentation in same format as original images, klb/tif/h5/npy files.")
+@click.option('--membrane_seg_dir',required=False, default='',
+              type=click.Path(file_okay=False,dir_okay=True,readable=True),
+              help="Directory with membrane segmentation in same format as original images, klb/tif/h5/npy files.")
+@click.option('--crop_dir',required=True,
+              type=click.Path(exists=True,file_okay=False,dir_okay=True,readable=True),
+              help="The directory with hpair.csv and vpair.csv generated with generate-cropboxes. "
+                   "This is also the OUTPUT directory.")
+@click.option("--cropbox_index","-cbi", required=False, default=0, type=click.INT,
+              help="The cropbox to visualize for cropping.")
+@click.option("--timestamp_min","-tb", required=False, default=0, type=click.INT,
+              help="The first timestamp to use for cropping.")
+@click.option("--timestamp_max","-te", required=False, default=-1, type=click.INT,
+              help="The last timestamp to use for cropping. Setting -1 means use to the last available.")
+@click.option("--offset","-of", required=False, default=150, type=click.INT,
+              help="The offset used during cropping.")
+@click.option("--cell_volume_cutoff", required=True, default=1024, type=click.FLOAT,
+              help="The cell volume below which cells are not considered.")
+@click.option("--max_margin", required=False, default=2048, type=click.INT,
+              help="Original size of images.")
+@click.option("--x_shift", required=False, default=-11, type=click.INT,
+              help="X shift for camera alignment. For our 210809 data, for Cdx2, Masha found x_shift = -11.")
+@click.option("--y_shift", required=False, default=15, type=click.INT,
+              help="Y shift for camera alignment. For our 210809 data, for Cdx2, Masha found y_shift = 15")
+def tf_align_simple(orig_image_dir, nucl_seg_dir, membrane_seg_dir,  crop_dir, cropbox_index,
+                timestamp_min, timestamp_max, offset, cell_volume_cutoff, max_margin, x_shift, y_shift):
+    click.echo('Extracting transcription factor intensity...')
+    t0 = time()
+    mem_tf_vals, nuc_tf_vals = quantify_tf(orig_image_dir, membrane_seg_dir, nucl_seg_dir, crop_dir,
+                                           cropbox_index, cell_volume_cutoff, timestamp_min,
+                                           timestamp_max, offset, max_margin, x_shift, y_shift)
+
+    with open(os.path.join(crop_dir,'membrane_tf.csv'), 'w') as f_out:
+        f_out.write("Timestamp, Label ID, Label Intensity\n")
+        for time_index, labels in mem_tf_vals.items():
+            for label_id, intensity in labels.items():
+                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity) + '\n')
+
+    with open(os.path.join(crop_dir,'nuclei_tf.csv'), 'w') as f_out:
+        f_out.write("Timestamp, Label ID, Label Intensity\n")
+        for time_index, labels in nuc_tf_vals.items():
+            for label_id, intensity in labels.items():
+                f_out.write(str(time_index) + ',' + str(label_id) + ',' + str(intensity) + '\n')
+
+    t1 = time() - t0
+    click.echo('Transcription factor intensity files generated here:' + crop_dir)
+    click.echo("Time elapsed: " + str(t1))
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
1. Read images masks in any file format.

2. Avoid pre-loading all masks.

3. Look for hand corrected nucl mask.

4. Removed hard coding of the max_time. Use the length of the file list to get it.

5. Added min_time option. 

6. Commandline interface.